### PR TITLE
Release/v2.0.0 beta 6

### DIFF
--- a/.bin/update_version.sh
+++ b/.bin/update_version.sh
@@ -19,6 +19,6 @@ echo "$PREV_VERSION -> $VERSION  (${PREV_VERSION//-/--} -> ${VERSION//-/--})"
 
 sed -e "s#Version-${PREV_VERSION//-/--}-information#Version-${VERSION//-/--}-information#g" -e "s#tag/v${PREV_VERSION}#tag/v${VERSION}#g" README.md > a; mv a README.md
 sed -e "s#version = \".*\"#version = \"${VERSION}\"#g" docs/config.toml > a ; mv a docs/config.toml
-sed "s/^version= /version = "${VERSION}"/g" Cargo.toml > a && mv a Cargo.toml
+sed "s/^version = \".*\"/version = \"${VERSION}\"/g" Cargo.toml > a && mv a Cargo.toml
 
 echo "Replace version from \"${PREV_VERSION}\" to \"${VERSION}\""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sibling"
-version = "2.0.0-beta-1"
+version = "2.0.0-beta-6"
 description = "get next/previous sibling directory name."
 repository = "https://github.com/tamada/sibling"
 homepage = "https://tamada.github.io/sibling"

--- a/assets/init/init.bash
+++ b/assets/init/init.bash
@@ -5,16 +5,16 @@ __change_directory_to_sibling() {
     fi
     step=1
     if [[ $# -eq 2 ]]; then
-       step=$2
+        step=$2
     fi
     next=$(sibling --type $traversing_type --csv --step $step)
     sibling_status=$?
-    result=$(echo $next | tr -s ',' ' ')
+    result=($(echo $next | tr -s ',' ' '))
     if [[ $sibling_status -eq 0 ]] ; then
-        cd ${result[1]}
-        echo "$PWD (${result[3]}/${result[4]})"
+        cd "$(echo ${result[2]} | xargs)"
+        echo "$PWD (${result[4]}/${result[5]})"
     else
-        echo "Done (${result[3]}/${result[4]})"
+        echo "Done (${result[4]}/${result[5]})"
         cd ..
     fi
     return $sibling_status
@@ -37,14 +37,15 @@ __ls_sibling() {
     fi
     step=1
     if [[ $# -eq 2 ]]; then
-       step=$2
+        step=$2
     fi
     next=$(sibling --absolute --type $traversing_type --csv --step $step)
     sibling_status=$?
-    result=$(echo $next | tr -s ',' ' ')
+    result=($(echo $next | tr -s ',' ' '))
     if [[ $sibling_status -eq 0 ]]; then
-        echo ${result[1]}
-        ls ${result[1]}
+        r=$(echo ${result[2]} | xargs)
+        echo "$r (${result[4]}/${result[5]})"
+        ls "$r"
     else
         echo "no more siblings"
     fi
@@ -59,7 +60,7 @@ lsprev() {
 }
 
 lsrand() {
-    __ls_sibling rand
+    __ls_sibling random
 }
 
 lsfirst() {

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -15,7 +15,7 @@ pygmentsStyle = "pygments"
     project_tagline = "get next/previous sibling directory name"
     dateFormat = "2006-01-02"
     katex = true
-    version = "2.0.0-beta-5"
+    version = "2.0.0-beta-6"
     footer = "[![GitHub](https://img.shields.io/badge/GitHub-tamada/sibling-blueviolet.svg?logo=github)](https://github.com/tamada/sibling) Made with [Hugo](https://gohugo.io/). Theme by [Cayman](https://github.com/zwbetz-gh/cayman-hugo-theme). Deployed to [GitHub Pages](https://pages.github.com/)."
 
 [menu]


### PR DESCRIPTION
- fix the `cdnext`, `cdprev` error, failed to refer the `sibling` results in `init.bash` script.
- fix the `update_version.sh` script for updating version of `Cargo.toml`.