### PR TITLE
Fix the site build of the publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "the version to publish, such as 3.0.0"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -14,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the release
-    if: startsWith(github.head_ref, 'release/v') && github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.head_ref, 'release/v') && github.event.pull_request.merged == true)
     outputs:
       appname: sibling
       tag: ${{ steps.vars.outputs.tag }}
@@ -23,7 +29,11 @@ jobs:
       - name: Git Tag Name
         id: vars
         run: |
-          echo "tag=${GITHUB_HEAD_REF##*/v}" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${GITHUB_HEAD_REF##*/v}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Create release
         id: create_release
@@ -48,7 +58,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.129.0'
+          hugo-version: '0.154.5'
           extended: true
 
       - name: Checkout

--- a/Justfile
+++ b/Justfile
@@ -35,7 +35,7 @@ prepare_site_build:
 
 # Generate the document site with Hugo
 site: prepare_site_build
-    hugo -s site
+    hugo -s docs
 
 # Build the docker image for gixor
 docker:


### PR DESCRIPTION
The publish workflow failed on the release of v3.0.0, at the `documents` job.

```
WARN  Module "github.com/nunocoracao/blowfish/v2" is not compatible with this Hugo version: 0.141.0/0.154.5 extended
Error: error building site: ".../blowfish/v2@v2.97.0/layouts/shortcodes/codeberg.html:5:1": parse failed: template: shortcodes/codeberg.html:5: function "try" not defined
```

The workflow pinned Hugo `0.129.0`, while the theme in `docs/go.mod` (blowfish v2.97.0)
asks for `0.141.0` or later; the `try` function of the template came in 0.141.0.

## What this does

- pin Hugo `0.154.5`, which is the newest one the theme tells it works with.
  Both 0.141.0 and 0.154.5 build the site of this repository; it was checked
  in a container before this change.
- make the workflow dispatchable by hand, with the version as its input.
- fix the `site` recipe of the Justfile, which ran hugo on `site`, not `docs`.

## The state of the v3.0.0 release

The failure left it half done, since the jobs after the site build were skipped.

| | |
|---|---|
| the tag `v3.0.0` | created |
| the release | created, **with no asset** |
| the site of gh-pages | **not deployed** (the last one is of 2026-07-25) |
| crates.io | **not published** (the latest is 2.0.x) |

Merging this, and then running the workflow by hand with `3.0.0`, completes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)