### PR TITLE
Release through the reusable workflows of tamada/.github

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,203 +1,149 @@
+# Releases sibling; tag, build, publish, and tell the world.
+#
+# The tagging, the site, and the publishing of the release are the reusable
+# workflows of tamada/.github; what is left here is what only this repository
+# knows, that is, building the command for each platform and publishing the
+# crate.
+#
+# The release is a draft until the last job, hence, the assets are attached
+# before anyone hears about it. The last job takes the draft off with the token
+# of the GitHub App, so that `release: published` fires and notify-publish.yaml
+# runs; a release published by GITHUB_TOKEN fires nothing.
+#
+# Merging a pull request from a release/vX.Y.Z branch runs it. The manual
+# dispatch is for the release which failed halfway; the version is the input,
+# since the branch of a dispatched run tells nothing about it.
 name: Publish
 
-on: 
+on:
   pull_request:
     branches:
       - main
     types: [closed]
   workflow_dispatch:
     inputs:
-      tag:
+      version:
         description: "the version to publish, such as 3.0.0"
         required: true
         type: string
 
-permissions:
-  contents: read
-
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # create the release
+  start:
     if: github.event_name == 'workflow_dispatch' || (startsWith(github.head_ref, 'release/v') && github.event.pull_request.merged == true)
-    outputs:
-      appname: sibling
-      tag: ${{ steps.vars.outputs.tag }}
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-    steps:
-      - name: Git Tag Name
-        id: vars
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${GITHUB_HEAD_REF##*/v}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create release
-        id: create_release
-        uses: marvinpinto/action-automatic-releases@latest
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: v${{ steps.vars.outputs.tag }}
-          title: Release v${{ steps.vars.outputs.tag }}
-          draft: false
-          prerelease: false
+    uses: tamada/.github/.github/workflows/release-start.yaml@v1
+    with:
+      # Empty on the pull request; the version comes from the head branch then.
+      version: ${{ inputs.version }}
+    permissions:
+      contents: write
 
   documents:
-    runs-on: ubuntu-latest
-    needs: setup
+    needs: start
+    uses: tamada/.github/.github/workflows/build-hugo-and-publish.yaml@v1
+    with:
+      workdir: docs
+      # The ref of this run is the pull request, not the branch which was tagged.
+      branch: main
+      # The theme of docs/go.mod, blowfish, asks for 0.141.0 or later, and tells
+      # it works up to 0.154.5.
+      hugo-version: "0.154.5"
     permissions:
-      contents: write # deploy the site to the gh-pages branch
-    outputs:
-      appname: ${{ needs.setup.outputs.appname }}
-      tag: ${{ needs.setup.outputs.tag }}
-      upload_url: ${{ needs.setup.outputs.upload_url }}
-    steps:
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-          hugo-version: '0.154.5'
-          extended: true
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 0
-
-      - name: Build Site
-        run: |
-          git worktree add docs/public gh-pages
-          (cd docs ; hugo)
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/public
+      contents: read
+      pages: write
+      id-token: write
 
   publish:
+    needs: start
     runs-on: ${{ matrix.os }}
-    needs: documents
     permissions:
-      contents: write # upload the assets to the release
-    outputs:
-      appname: ${{ needs.documents.outputs.appname }}
-      tag: ${{ needs.documents.outputs.tag }}
+      contents: write # attach the assets to the draft release
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            artifact_name: ${{ needs.documents.outputs.appname }}
-            asset_name: ${{ needs.documents.outputs.appname }}-${{ needs.documents.outputs.tag }}_linux_arm64
-            ext: ''
+            platform: linux_arm64
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            artifact_name: ${{ needs.documents.outputs.appname }}
-            asset_name: ${{ needs.documents.outputs.appname }}-${{ needs.documents.outputs.tag }}_linux_amd64
-            ext: ''
-          # - os: ubuntu-latest
-          #   target: aarch64-pc-windows-gnullvm
-          #   artifact_name: ${{ needs.documents.outputs.appname }}.exe
-          #   asset_name: ${{ needs.documents.outputs.appname }}-${{ needs.documents.outputs.tag }}_windows_arm64
-          #   ext: '.exe'
-          # - os: ubuntu-latest
-          #   target: x86_64-pc-windows-gnu
-          #   artifact_name: ${{ needs.documents.outputs.appname }}.exe
-          #   asset_name: ${{ needs.documents.outputs.appname }}-${{ needs.documents.outputs.tag }}_windows_amd64
-          #   ext: '.exe'
+            platform: linux_amd64
           - os: macos-latest
             target: aarch64-apple-darwin
-            artifact_name: ${{ needs.documents.outputs.appname }}
-            asset_name: ${{ needs.documents.outputs.appname }}-${{ needs.documents.outputs.tag }}_darwin_arm64
-            ext: ''
+            platform: darwin_arm64
           - os: macos-latest
             target: x86_64-apple-darwin
-            artifact_name: ${{ needs.documents.outputs.appname }}
-            asset_name: ${{ needs.documents.outputs.appname }}-${{ needs.documents.outputs.tag }}_darwin_amd64
-            ext: ''
+            platform: darwin_amd64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
-      
-      - name: Setup variables
-        id: vars
-        shell: bash
-        run: |
-          DIR=$(echo "${{ needs.documents.outputs.appname }}-${{ needs.documents.outputs.tag }}")
-          echo "dir=$DIR" >> $GITHUB_OUTPUT
+
       - name: Setup Rust
         run: rustup update stable
 
-      - name: Setup Rust (1/2) (toolchain)
+      - name: Setup the cross toolchain
         uses: taiki-e/setup-cross-toolchain-action@v1
         if: matrix.os == 'ubuntu-latest'
         with:
           target: ${{ matrix.target }}
 
-      - name: Cross build (macOS)
-        if: matrix.os == 'macos-latest'
+      - name: Build
         run: |
           rustup target add ${{ matrix.target }}
           cargo build --release --target ${{ matrix.target }}
 
-      - name: Cross build (Linux and Windows)
-        run: |
-          cargo build --release --target ${{ matrix.target }}
-
-      # Regenerate them so that the release never ships the stale ones; note
-      # that the option which generates them is available on the debug build.
-      - name: Generate completion files
+      # The option which generates them is on the debug build only, hence, this
+      # runs before packaging, and the release never ships the stale ones.
+      - name: Generate the completion files
         run: cargo run -- --generate-completion-files --completion-out-dir assets/completions
 
-      # publish release
-      - name: Create release file
+      - name: Create the asset
+        id: asset
         shell: bash
-        run: |
-          DIR=${{ steps.vars.outputs.dir }}
-          DIST=${{ matrix.target }}
-          mkdir -p dist/$DIST/$DIR
-          # cp -r site/public dist/$DIST/$DIR/docs
-          cp -r README.md LICENSE assets/completions dist/$DIST/$DIR
-          cp target/${{ matrix.target }}/release/${{ matrix.artifact_name }} dist/$DIST/$DIR/sibling${{ matrix.ext}}
-          tar cvfz dist/${{ matrix.asset_name }}.tar.gz -C dist/$DIST $DIR
-
-      - name: Upload release assets
-        id: upload-release-assets
-        uses: actions/upload-release-asset@v1.0.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_path: dist/${{ matrix.asset_name }}.tar.gz
-          asset_name: ${{ matrix.asset_name }}.tar.gz
-          asset_content_type: application/x-gzip
-          upload_url: ${{ needs.documents.outputs.upload_url }}
+          APPNAME: ${{ needs.start.outputs.appname }}
+          VERSION: ${{ needs.start.outputs.version }}
+        run: |
+          dir="${APPNAME}-${VERSION}"
+          asset="${dir}_${{ matrix.platform }}.tar.gz"
+          mkdir -p "dist/${dir}"
+          cp -r README.md LICENSE assets/completions "dist/${dir}"
+          cp "target/${{ matrix.target }}/release/${APPNAME}" "dist/${dir}/${APPNAME}"
+          tar cvfz "dist/${asset}" -C dist "${dir}"
+          echo "path=dist/${asset}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload the asset to the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ needs.start.outputs.tag }}" "${{ steps.asset.outputs.path }}" --clobber
 
   publish_to_crates_io:
+    needs: [start, publish]
     runs-on: ubuntu-latest
-    needs: publish
     permissions:
       contents: read
       id-token: write # the trusted publishing of crates.io uses OIDC
-    outputs:
-      appname: ${{ needs.publish.outputs.appname }}
-      tag: ${{ needs.publish.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main
 
-      - name: Authenticate with custom registry
+      - name: Authenticate with crates.io
         id: auth
         uses: rust-lang/crates-io-auth-action@v1
 
-      - name: publish
+      - name: Publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run:
-          cargo publish --package sibling
+        run: cargo publish
+
+  finish:
+    needs: [start, documents, publish, publish_to_crates_io]
+    uses: tamada/.github/.github/workflows/release-finish.yaml@v1
+    with:
+      tag: ${{ needs.start.outputs.tag }}
+    permissions:
+      contents: write
+    secrets: inherit

--- a/.github/workflows/versionup.yaml
+++ b/.github/workflows/versionup.yaml
@@ -14,8 +14,8 @@ jobs:
       - name: Get branches
         id: vars
         run: |
-          echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
-          echo "tag=${GITHUB_REF##**/v}" >> $GITHUB_OUTPUT
+          echo "branch=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
+          echo "tag=${GITHUB_REF##**/v}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,7 +25,6 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "action@github.com"
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
 
       - name: Version up
         id: updating_version


### PR DESCRIPTION
The publish workflow tagged, released, and deployed the site by itself. This
hands those to the reusable workflows of `tamada/.github@v1`, and keeps here
what only this repository knows.

| job | what runs it |
|---|---|
| `start` | `release-start.yaml@v1` — tags main, opens the release **as a draft** |
| `documents` | `build-hugo-and-publish.yaml@v1` — builds `docs`, deploys to Pages |
| `publish` | this repository — builds the command for four platforms, attaches the assets |
| `publish_to_crates_io` | this repository — trusted publishing |
| `finish` | `release-finish.yaml@v1` — publishes the draft with the App token |

## Two things this fixes

**The site deployment was broken, quietly.** Pages of this repository serves what a
workflow uploads (`build_type: workflow`), while the workflow pushed the built site to
the `gh-pages` branch. The job succeeded, the branch moved, and Pages kept serving the
older site; it still tells `v2.0.5` today, after v3.0.0 was released. The last Pages
deployment is of 2026-07-25.

**`notify-publish.yaml` has never run.** A release published by `GITHUB_TOKEN` does not
fire `release: published`. `release-finish` publishes the draft with the token of the
GitHub App, which does fire it.

## Before merging: one secret is needed

`release-finish` reads `APP_CLIENT_ID` and `APP_PRIVATE_KEY` through `secrets: inherit`.
This repository has `APP_PRIVATE_KEY` and **`CLIENT_ID`**, which does not match by name
and therefore never arrives.

Add `APP_CLIENT_ID` with the same value as `CLIENT_ID` (or rename it, and update
`notify-publish.yaml` which reads `CLIENT_ID`).

Without it the release is still published, using `GITHUB_TOKEN`, and the job says so in
its log — but `notify-publish` would stay silent as before.

## Notes

- The manual dispatch is kept, with `version` as its input, so a release which failed
  halfway is completed without merging a pull request again.
- Hugo stays pinned at `0.154.5`; the blowfish theme of `docs/go.mod` asks for 0.141.0
  or later and tells it works up to 0.154.5.
- `actionlint` reports two findings on `notify-publish.yaml`, both false: its bundled
  metadata for `actions/create-github-app-token@v3` is stale, and the upstream action
  does accept `client-id`. The reusable `release-finish` uses the same input.
- The `gh-pages` branch is left as it is; nothing serves from it any more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)