### PR TITLE
Deploy the document site on every change of docs

### DIFF
--- a/.github/workflows/deploy-page.yaml
+++ b/.github/workflows/deploy-page.yaml
@@ -1,0 +1,30 @@
+# Deploys the document site to GitHub Pages whenever it changes on main.
+#
+# The release does not deploy the site any more. A release changes the version
+# badges of docs, hence, this workflow runs on the merge as well, and Pages
+# rejects a second deployment while one is in flight rather than queueing it.
+# Keeping the deployment in one place is what avoids that race.
+name: deploy documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - ".github/workflows/deploy-page.yaml"
+  workflow_dispatch:
+
+jobs:
+  document:
+    uses: tamada/.github/.github/workflows/build-hugo-and-publish.yaml@v1
+    with:
+      workdir: docs
+      # The blowfish theme of docs/go.mod tells it works from 0.141.0 up to
+      # 0.154.5, while 0.158.0 builds this site as well. It is pinned so that a
+      # new Hugo cannot break the deployment without anyone asking for it.
+      hugo-version: "0.158.0"
+    permissions:
+      contents: read
+      pages: write
+      id-token: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,9 @@
 # Releases sibling; tag, build, publish, and tell the world.
 #
-# The tagging, the site, and the publishing of the release are the reusable
-# workflows of tamada/.github; what is left here is what only this repository
-# knows, that is, building the command for each platform and publishing the
-# crate.
+# The tagging and the publishing of the release are the reusable workflows of
+# tamada/.github; what is left here is what only this repository knows, that is,
+# building the command for each platform and publishing the crate. The site is
+# deployed by deploy-page.yaml, on every change of docs on main.
 #
 # The release is a draft until the last job, hence, the assets are attached
 # before anyone hears about it. The last job takes the draft off with the token
@@ -36,21 +36,6 @@ jobs:
       version: ${{ inputs.version }}
     permissions:
       contents: write
-
-  documents:
-    needs: start
-    uses: tamada/.github/.github/workflows/build-hugo-and-publish.yaml@v1
-    with:
-      workdir: docs
-      # The ref of this run is the pull request, not the branch which was tagged.
-      branch: main
-      # The theme of docs/go.mod, blowfish, asks for 0.141.0 or later, and tells
-      # it works up to 0.154.5.
-      hugo-version: "0.154.5"
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
 
   publish:
     needs: start
@@ -140,7 +125,7 @@ jobs:
         run: cargo publish
 
   finish:
-    needs: [start, documents, publish, publish_to_crates_io]
+    needs: [start, publish, publish_to_crates_io]
     uses: tamada/.github/.github/workflows/release-finish.yaml@v1
     with:
       tag: ${{ needs.start.outputs.tag }}

--- a/Justfile
+++ b/Justfile
@@ -30,11 +30,8 @@ test_init:
 completions:
     cargo run -- --generate-completion-files --completion-out-dir assets/completions
 
-prepare_site_build:
-    test -d docs/public || git worktree add -f docs/public gh-pages
-
 # Generate the document site with Hugo
-site: prepare_site_build
+site:
     hugo -s docs
 
 # Build the docker image for gixor


### PR DESCRIPTION
Takes the workflow you added, and hands its body to the reusable
`build-hugo-and-publish.yaml@v1` — the same one the release used.

## What the copied workflow would have hit

| | |
|---|---|
| `actions/upload-pages-artifact@v3` with `actions/deploy-pages@v5` | not of the same generation; v5 pairs with v5 |
| no `concurrency` group | Pages rejects a second deployment in flight rather than queueing it, and this workflow and the release both fire on the merge of a release branch |
| `hugo-version: 0.158.0` | fine — it was checked, see below |

Its trigger is kept as it was: the push to `main` which touches `docs`, and the
manual dispatch.

## The site is deployed here now, not by the release

The `documents` job is dropped from `publish.yaml`. A release changes the version
badges under `docs`, so both would have run on the same merge and raced for the
single deployment Pages allows.

A fix of the documents now reaches the site without waiting for a release, which
is the other half of why this is worth splitting.

## Hugo

Pinned at `0.158.0`. The blowfish theme of `docs/go.mod` declares 0.141.0 to
0.154.5; 0.141.0, 0.154.5, and 0.158.0 were each run against this site in a
container, and all of them build it. Pinning is deliberate: `latest` is 0.164.0
today, which nobody has tried here, and a failure would only show up as a site
which quietly stops updating.

## After merging

The live site still tells v2.0.5. Running this workflow by hand brings it to
3.0.0.

```bash
gh workflow run deploy-page.yaml --ref main
```

Also drops `prepare_site_build` of the Justfile, which made a worktree of
`gh-pages` on `docs/public`; nothing serves from that branch any more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)